### PR TITLE
Lending iterator fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "regex-splitter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "regex",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regex-splitter"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/src/bin/readme.rs
+++ b/src/bin/readme.rs
@@ -25,6 +25,7 @@ Example code adapted from the README.md of
 [the regex-chunker crate](https://github.com/d2718/regex-chunker).
 */
 use regex::bytes::Regex;
+use regex_splitter::LendingIterator;
 use std::error::Error;
 
 fn example() -> Result<(), Box<dyn Error>> {
@@ -35,9 +36,9 @@ fn example() -> Result<(), Box<dyn Error>> {
 
     let mut stdin = std::io::stdin();
     let re = Regex::new(r#"[ "\r\n.,!?:;/]+"#)?;
-    let chunker = RegexSplitter::new(&mut stdin, &re);
+    let mut chunker = RegexSplitter::new(&mut stdin, &re);
 
-    for chunk in chunker {
+    while let Some(chunk) = chunker.next() {
         let word = String::from_utf8_lossy(&chunk?).to_lowercase();
         *counts.entry(word).or_default() += 1;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,6 @@ use regex::bytes::Regex;
 /// An `Iterator` that scans a `Read`, searches for the `delimiter`, and yields
 /// the non-delimiter bytes.
 ///
-/// This implementation incurs a new allocation when yielding, and the caller
-/// owns it. An alternate implementation using generic associated types that
-/// avoids the allocation is possible.
-///
 /// This implementation uses a private buffer that will grow proportional to the
 /// largest span of bytes between instances of `delimiter`.
 pub struct RegexSplitter<'a, 'b> {
@@ -74,10 +70,18 @@ impl<'a, 'b> RegexSplitter<'a, 'b> {
     }
 }
 
-impl<'a, 'b> Iterator for RegexSplitter<'a, 'b> {
-    type Item = Result<Vec<u8>>;
+pub trait LendingIterator {
+    type Item<'a>
+    where
+        Self: 'a;
 
-    fn next(&mut self) -> Option<Self::Item> {
+    fn next<'a>(&'a mut self) -> Option<Self::Item<'a>>;
+}
+
+impl<'a, 'b> LendingIterator for RegexSplitter<'a, 'b> {
+    type Item<'c> = Result<&'c [u8]> where Self: 'c;
+
+    fn next<'c>(&'c mut self) -> Option<Self::Item<'c>> {
         if let Err(error) = self.fill() {
             return Some(Err(error));
         }
@@ -100,16 +104,16 @@ impl<'a, 'b> Iterator for RegexSplitter<'a, 'b> {
             self.start += m.end();
             let r = if m.start() == 0 {
                 // We matched the delimiter at the beginning of the section.
-                Ok(Vec::new())
+                Ok(&section[0..0])
             } else {
                 // We matched a record.
-                Ok(section[0..m.start()].to_vec())
+                Ok(&section[0..m.start()])
             };
             Some(r)
         } else {
             // Last record, with no trailing delimiter.
             self.start = self.end;
-            Some(Ok(section.to_vec()))
+            Some(Ok(section))
         }
     }
 }
@@ -120,7 +124,7 @@ mod tests {
     use std::io::{Seek, SeekFrom, Write};
     use tempfile::tempfile;
 
-    use crate::RegexSplitter;
+    use crate::{LendingIterator, RegexSplitter};
 
     // Makes debugging easier than `DEFAULT_CAPACITY`, which fills the terminal
     // with junk.
@@ -136,10 +140,10 @@ mod tests {
         let mut splitter = RegexSplitter::with_capacity(&mut file, &delimiter, SMALL_CAPACITY);
 
         let r = splitter.next().unwrap().unwrap();
-        assert_eq!(b"hello", r.as_slice());
+        assert_eq!(b"hello", r);
 
         let r = splitter.next().unwrap().unwrap();
-        assert_eq!(b"world", r.as_slice());
+        assert_eq!(b"world", r);
 
         assert!(splitter.next().is_none());
     }
@@ -158,10 +162,10 @@ mod tests {
         let mut splitter = RegexSplitter::with_capacity(&mut file, &delimiter, SMALL_CAPACITY);
 
         let r = splitter.next().unwrap().unwrap();
-        assert_eq!(b"greetings", r.as_slice());
+        assert_eq!(b"greetings", r);
 
         let r = splitter.next().unwrap().unwrap();
-        assert_eq!(b"world", r.as_slice());
+        assert_eq!(b"world", r);
 
         assert!(splitter.next().is_none());
     }


### PR DESCRIPTION
This is based on #1. I first inlined `fill()`, but that didn't fix things. I then eliminated the `section` variable binding, and instead re-sliced `self.buffer` each place `section` was previously used, and that fixed conflicts between borrows.